### PR TITLE
[Feature] 관리자 생성

### DIFF
--- a/backend/src/main/java/com/ll/cafeservice/domain/admin/controller/v1/AdminControllerV1.java
+++ b/backend/src/main/java/com/ll/cafeservice/domain/admin/controller/v1/AdminControllerV1.java
@@ -1,14 +1,13 @@
-package com.ll.cafeservice.domain.user.controller.v1;
+package com.ll.cafeservice.domain.admin.controller.v1;
 
 import com.ll.cafeservice.api.Result;
-import com.ll.cafeservice.domain.user.dto.request.LoginRequest;
-import com.ll.cafeservice.domain.user.dto.response.LoginResponse;
+import com.ll.cafeservice.domain.admin.dto.request.LoginRequest;
+import com.ll.cafeservice.domain.admin.dto.response.LoginResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.service.spi.ServiceException;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user")
-public class UserControllerV1 {
+public class AdminControllerV1 {
 
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "")

--- a/backend/src/main/java/com/ll/cafeservice/domain/admin/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/ll/cafeservice/domain/admin/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.ll.cafeservice.domain.user.dto.request;
+package com.ll.cafeservice.domain.admin.dto.request;
 
 public record LoginRequest (
     String username,

--- a/backend/src/main/java/com/ll/cafeservice/domain/admin/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/ll/cafeservice/domain/admin/dto/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.ll.cafeservice.domain.user.dto.response;
+package com.ll.cafeservice.domain.admin.dto.response;
 
 import org.springframework.lang.NonNull;
 

--- a/backend/src/main/java/com/ll/cafeservice/domain/admin/service/AdminService.java
+++ b/backend/src/main/java/com/ll/cafeservice/domain/admin/service/AdminService.java
@@ -1,0 +1,28 @@
+package com.ll.cafeservice.domain.admin.service;
+
+import com.ll.cafeservice.entity.admin.Admin;
+import com.ll.cafeservice.entity.admin.AdminRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminService {
+
+    private final AdminRepository adminRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public AdminService(AdminRepository adminRepository, BCryptPasswordEncoder passwordEncoder) {
+        this.adminRepository = adminRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public Admin createAdmin(String username, String rawPassword) {
+        Admin admin = Admin.builder()
+            .username(username)
+            .password(rawPassword)
+            .build();
+        admin.encodePassword(passwordEncoder);
+        return adminRepository.save(admin);
+    }
+
+}

--- a/backend/src/main/java/com/ll/cafeservice/domain/admin/service/AdminService.java
+++ b/backend/src/main/java/com/ll/cafeservice/domain/admin/service/AdminService.java
@@ -2,11 +2,13 @@ package com.ll.cafeservice.domain.admin.service;
 
 import com.ll.cafeservice.entity.admin.Admin;
 import com.ll.cafeservice.entity.admin.AdminRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class AdminService {
 
     private final AdminRepository adminRepository;
@@ -17,11 +19,6 @@ public class AdminService {
 
     @Value("${ADMIN_PASSWORD}")
     private String adminPassword;
-
-    public AdminService(AdminRepository adminRepository, BCryptPasswordEncoder passwordEncoder) {
-        this.adminRepository = adminRepository;
-        this.passwordEncoder = passwordEncoder;
-    }
 
     public Admin createAdmin(String username, String rawPassword) {
         Admin admin = Admin.builder()

--- a/backend/src/main/java/com/ll/cafeservice/domain/admin/service/AdminService.java
+++ b/backend/src/main/java/com/ll/cafeservice/domain/admin/service/AdminService.java
@@ -25,4 +25,15 @@ public class AdminService {
         return adminRepository.save(admin);
     }
 
+    public boolean existsByUsername(String username) {
+        return adminRepository.existsByUsername(username);
+    }
+
+    public void createAdminAccountIfNotExist() {
+        String adminUsername = "admin";
+        String adminRawPassword = "1234";
+        if (!existsByUsername(adminUsername)) {
+            createAdmin(adminUsername, adminRawPassword);
+        }
+    }
 }

--- a/backend/src/main/java/com/ll/cafeservice/domain/admin/service/AdminService.java
+++ b/backend/src/main/java/com/ll/cafeservice/domain/admin/service/AdminService.java
@@ -2,6 +2,7 @@ package com.ll.cafeservice.domain.admin.service;
 
 import com.ll.cafeservice.entity.admin.Admin;
 import com.ll.cafeservice.entity.admin.AdminRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -10,6 +11,12 @@ public class AdminService {
 
     private final AdminRepository adminRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+
+    @Value("${ADMIN_USERNAME}")
+    private String adminUsername;
+
+    @Value("${ADMIN_PASSWORD}")
+    private String adminPassword;
 
     public AdminService(AdminRepository adminRepository, BCryptPasswordEncoder passwordEncoder) {
         this.adminRepository = adminRepository;
@@ -25,15 +32,9 @@ public class AdminService {
         return adminRepository.save(admin);
     }
 
-    public boolean existsByUsername(String username) {
-        return adminRepository.existsByUsername(username);
-    }
-
     public void createAdminAccountIfNotExist() {
-        String adminUsername = "admin";
-        String adminRawPassword = "1234";
-        if (!existsByUsername(adminUsername)) {
-            createAdmin(adminUsername, adminRawPassword);
+        if (!adminRepository.existsByUsername(adminUsername)) {
+            createAdmin(adminUsername, adminPassword);
         }
     }
 }

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
@@ -35,8 +35,4 @@ public class Admin extends BaseEntity {
         this.password = passwordEncoder.encode(this.password);
     }
 
-    @Override
-    public String toString() {
-        return "{ username = " + username + ", password = " + password + " }";
-    }
 }

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
@@ -9,9 +9,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -31,5 +33,10 @@ public class Admin extends BaseEntity {
 
     public void encodePassword(BCryptPasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(this.password);
+    }
+
+    @Override
+    public String toString() {
+        return "{ username = " + username + ", password = " + password + " }";
     }
 }

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
@@ -18,7 +18,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "admin")
+@Table(name = "admins")
 public class Admin extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
@@ -7,8 +7,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "admin")
 public class Admin extends BaseEntity {

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @Builder
@@ -34,6 +35,10 @@ public class Admin extends BaseEntity {
 
     public void encodePassword(BCryptPasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(this.password);
+    }
+
+    public boolean isPasswordValid(PasswordEncoder encoder, String rawPassword) {
+        return encoder.matches(rawPassword, this.password);
     }
 
 }

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,8 +16,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "admins")
 public class Admin extends BaseEntity {

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
@@ -1,0 +1,39 @@
+package com.ll.cafeservice.entity.admin;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Setter
+@Getter
+@Entity
+@Table(name = "admin")
+public class Admin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    public void encodePassword(BCryptPasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(this.password);
+    }
+}

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/Admin.java
@@ -1,21 +1,17 @@
 package com.ll.cafeservice.entity.admin;
 
+import com.ll.cafeservice.entity.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-@Setter
-@Getter
 @Entity
 @Table(name = "admin")
-public class Admin {
+public class Admin extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,12 +22,6 @@ public class Admin {
 
     @Column(nullable = false)
     private String password;
-
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
-
-    @Column(nullable = false)
-    private LocalDateTime updatedAt = LocalDateTime.now();
 
     public void encodePassword(BCryptPasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(this.password);

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/AdminRepository.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/AdminRepository.java
@@ -1,8 +1,7 @@
 package com.ll.cafeservice.entity.admin;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdminRepository extends JpaRepository<Admin, Long> {
-    Optional<Admin> findByUsername(String username);
+    boolean existsByUsername(String username);
 }

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/AdminRepository.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/AdminRepository.java
@@ -1,0 +1,8 @@
+package com.ll.cafeservice.entity.admin;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+    Optional<Admin> findByUsername(String username);
+}

--- a/backend/src/main/java/com/ll/cafeservice/entity/admin/AdminRepository.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/admin/AdminRepository.java
@@ -1,7 +1,10 @@
 package com.ll.cafeservice.entity.admin;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdminRepository extends JpaRepository<Admin, Long> {
     boolean existsByUsername(String username);
+
+    Optional<Object> findByUsername(String testAdmin);
 }

--- a/backend/src/main/java/com/ll/cafeservice/entity/base/BaseEntity.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/base/BaseEntity.java
@@ -14,8 +14,8 @@ import java.time.LocalDateTime;
 public class BaseEntity {
 
     @CreatedDate
-    private LocalDateTime createdDate;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime modifiedDate;
+    private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/com/ll/cafeservice/entity/base/BaseEntity.java
+++ b/backend/src/main/java/com/ll/cafeservice/entity/base/BaseEntity.java
@@ -3,6 +3,7 @@ package com.ll.cafeservice.entity.base;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,6 @@ public class BaseEntity {
     @CreatedDate
     private LocalDateTime createdDate;
 
-    @CreatedDate
+    @LastModifiedDate
     private LocalDateTime modifiedDate;
 }

--- a/backend/src/main/java/com/ll/cafeservice/global/DevInitData.java
+++ b/backend/src/main/java/com/ll/cafeservice/global/DevInitData.java
@@ -1,5 +1,6 @@
 package com.ll.cafeservice.global;
 
+import com.ll.cafeservice.domain.admin.service.AdminService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,14 +19,18 @@ public class DevInitData {
     @Lazy
     private DevInitData self;
 
+    private final AdminService adminService;
+
     @Bean
     public ApplicationRunner devInitDataApplicationRunner() {
         return args -> {
             Ut.file.downloadByHttp("http://localhost:8080/v3/api-docs/apiV1", ".");
-           log.info("TypeScript");
+            log.info("TypeScript");
 
             String cmd = "yes | npx --package typescript --package openapi-typescript openapi-typescript apiV1.json -o ../frontend/src/lib/backend/apiV1/schema.d.ts";
             Ut.cmd.runAsync(cmd);
+
+            adminService.createAdminAccountIfNotExist();
         };
     }
 }

--- a/backend/src/main/java/com/ll/cafeservice/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ll/cafeservice/global/config/SecurityConfig.java
@@ -1,28 +1,33 @@
 package com.ll.cafeservice.global.config;
 
+import java.util.Arrays;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
-
 @Configuration
 public class SecurityConfig {
 
     @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .authorizeHttpRequests(authorize -> authorize
+            .csrf(AbstractHttpConfigurer::disable)
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .authorizeHttpRequests(authorize -> authorize
 
-                        .anyRequest().permitAll() // 모든 경로 허용
-                );
+                .anyRequest().permitAll() // 모든 경로 허용
+            );
         return http.build();
     }
 

--- a/backend/src/test/java/com/ll/cafeservice/domain/admin/service/AdminServiceTest.java
+++ b/backend/src/test/java/com/ll/cafeservice/domain/admin/service/AdminServiceTest.java
@@ -41,4 +41,13 @@ class AdminServiceTest {
         assertEquals(admin.getUsername(), createdAdmin.getUsername());
         assertTrue(encoder.matches("1234", createdAdmin.getPassword()));
     }
+
+    @Test
+    @DisplayName("삽입된 데이터 검증 테스트")
+    void testSavedAdminData() {
+        adminService.createAdmin("testAdmin", "1234");
+        Admin foundAdmin = (Admin) adminRepository.findByUsername("testAdmin").orElseThrow();
+        assertEquals(admin.getUsername(), foundAdmin.getUsername());
+        assertTrue(encoder.matches("1234", foundAdmin.getPassword()));
+    }
 }

--- a/backend/src/test/java/com/ll/cafeservice/domain/admin/service/AdminServiceTest.java
+++ b/backend/src/test/java/com/ll/cafeservice/domain/admin/service/AdminServiceTest.java
@@ -20,34 +20,28 @@ class AdminServiceTest {
     @Autowired
     private AdminRepository adminRepository;
 
-    private Admin admin;
     private BCryptPasswordEncoder encoder;
 
     @BeforeEach
     void setup() {
         adminRepository.deleteAll();
         encoder = new BCryptPasswordEncoder();
-        admin = Admin.builder()
-            .username("testAdmin")
-            .password("1234")
-            .build();
-        admin.encodePassword(encoder);
     }
 
     @Test
     @DisplayName("데이터 삽입 테스트")
     void testInsertAdminData() {
         Admin createdAdmin = adminService.createAdmin("testAdmin", "1234");
-        assertEquals(admin.getUsername(), createdAdmin.getUsername());
-        assertTrue(encoder.matches("1234", createdAdmin.getPassword()));
+        assertEquals("testAdmin", createdAdmin.getUsername());
+        assertTrue(createdAdmin.isPasswordValid(encoder, "1234"));
     }
 
     @Test
     @DisplayName("삽입된 데이터 검증 테스트")
     void testSavedAdminData() {
-        adminService.createAdmin("testAdmin", "1234");
+        adminService.createAdmin("testAdmin", "5678");
         Admin foundAdmin = (Admin) adminRepository.findByUsername("testAdmin").orElseThrow();
-        assertEquals(admin.getUsername(), foundAdmin.getUsername());
-        assertTrue(encoder.matches("1234", foundAdmin.getPassword()));
+        assertEquals("testAdmin", foundAdmin.getUsername());
+        assertTrue(foundAdmin.isPasswordValid(encoder, "5678"));
     }
 }

--- a/backend/src/test/java/com/ll/cafeservice/domain/admin/service/AdminServiceTest.java
+++ b/backend/src/test/java/com/ll/cafeservice/domain/admin/service/AdminServiceTest.java
@@ -1,0 +1,44 @@
+package com.ll.cafeservice.domain.admin.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.ll.cafeservice.entity.admin.Admin;
+import com.ll.cafeservice.entity.admin.AdminRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@SpringBootTest
+class AdminServiceTest {
+
+    @Autowired
+    private AdminService adminService;
+    @Autowired
+    private AdminRepository adminRepository;
+
+    private Admin admin;
+    private BCryptPasswordEncoder encoder;
+
+    @BeforeEach
+    void setup() {
+        adminRepository.deleteAll();
+        encoder = new BCryptPasswordEncoder();
+        admin = Admin.builder()
+            .username("testAdmin")
+            .password("1234")
+            .build();
+        admin.encodePassword(encoder);
+    }
+
+    @Test
+    @DisplayName("데이터 삽입 테스트")
+    void testInsertAdminData() {
+        Admin createdAdmin = adminService.createAdmin("testAdmin", "1234");
+        assertEquals(admin.getUsername(), createdAdmin.getUsername());
+        assertTrue(encoder.matches("1234", createdAdmin.getPassword()));
+    }
+}


### PR DESCRIPTION
## 🌿 반영 브랜치
security/admin -> main

## 🛠 작업 내용
- BaseEntity의 변수명 수정 및 updatedAt의 어노테이션 변경
- 관리자 테이블 설정
- user domain을 admin으로 변경
- 관리자 계정 생성 로직 구현
- DevInitData에 관리자 생성 로직 추가
- 간단한 테스트 코드 구현

## 🔗 관련 이슈
Closes #1 

## 📋참고사항
 .env 파일에 아래와 같이 데이터 추가해야 합니다.
```
ADMIN_USERNAME= 
ADMIN_PASSWORD=
```

## 💬 리뷰 요구사항 (선택)
- admin에 getter를 지양하고 싶은데 테스트 코드를 작성하다보니 getter를 사용하였습니다. 지양하려면 어떤 방식으로 해야할까요?
- '네이밍이 아쉽거나나 테스트코드가 이게 더 있었으면 좋겠다.' 등 의견 있으시면 자유롭게 남겨주세요.

- 의견 많이 남겨주셔서 소통해주시면 좋습니다. ex) 이건 왜 이런식으로 구현했나요?
