### PR TITLE
[Feature] 관리자 로그인 페이지 추가

### DIFF
--- a/frontend/src/app/(with-admin)/admin/layout.tsx
+++ b/frontend/src/app/(with-admin)/admin/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
+
+const geistSans = Geist({
+    variable: "--font-geist-sans",
+    subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+    variable: "--font-geist-mono",
+    subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+    title: "Grids & Circles Admin",
+    description: "당신을 위한 최고의 쇼핑 경험",
+};
+
+export default function AdminRootLayout({
+                                       children,
+                                   }: Readonly<{
+    children: React.ReactNode;
+}>) {
+    return (
+        <html lang="ko">
+        <body
+            className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-gray-50`}
+        >
+        {children}
+        </body>
+        </html>
+    );
+}

--- a/frontend/src/app/(with-admin)/admin/login/layout.tsx
+++ b/frontend/src/app/(with-admin)/admin/login/layout.tsx
@@ -1,0 +1,5 @@
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+    return (
+        <>{children}</>
+    );
+}

--- a/frontend/src/app/(with-admin)/admin/login/page.tsx
+++ b/frontend/src/app/(with-admin)/admin/login/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import {useEffect, useState} from "react";
+import { useRouter } from "next/navigation";
+
+export default function LoginPage() {
+    const [adminId, setAdminId] = useState("");
+    const [password, setPassword] = useState("");
+    const [error, setError] = useState("");
+    const [loading, setLoading] = useState(false); // 서버 요청 대기 상태
+    const router = useRouter();
+
+    // 서버 응답 상태 코드에 따른 에러 처리, 관리자 페이지에서만 사용
+    function handleErrorResponse(response: Response) {
+        if (!response.ok) {
+            switch (response.status) {
+                case 401:
+                    throw new Error("인증 실패: 아이디 또는 비밀번호가 잘못되었습니다.");
+                case 403:
+                    throw new Error("접근 권한이 없습니다.");
+                case 500:
+                    throw new Error("서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+                default:
+                    throw new Error(`알 수 없는 오류가 발생했습니다. 상태 코드: ${response.status}`);
+            }
+        }
+    }
+
+    // // 헤더 스타일 변경(테스트중) - 한얼FT님 작성(수정예정)
+    // useEffect(() => {
+    //     const header = document.getElementById("main-header")
+    //     if (!header)return;
+    //     header.style
+    // }, []);
+
+    // 로그인 요청 핸들러
+    async function handleLogin(event: React.FormEvent) {
+        event.preventDefault(); // 폼 기본 동작 중단
+        setLoading(true); // 로딩 상태 시작
+        setError(""); // 기존 에러 초기화
+
+        try {
+            const response = await fetch("/api/auth/login", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ adminId, password }), // JSON 형태로 요청 데이터 전송
+            });
+
+            handleErrorResponse(response); // 응답 상태 코드에 따른 에러 처리
+
+            const data = await response.json(); // JSON 형태로 응답 데이터 파싱
+
+            // document.cookie = `token=${data.token}; path=/; secure; httponly`; // 보안 부분
+
+            router.push("/admin/board"); // 관리자 페이지로 이동
+        } catch (err : any) {
+            setError(err.message); // 에러 메시지 표시
+
+            console.error(`Login error: ${err.message}`); // 디버깅용 로깅
+        } finally {
+            setLoading(false); // 로딩 상태 종료
+        }
+    }
+
+    return (
+        <div className="flex items-center justify-center min-h-screen bg-gray-100">
+            <div className="w-full max-w-md p-8 bg-white rounded-lg shadow-lg">
+                <h1 className="text-2xl font-bold text-gray-800 text-center mb-6">GC Coffee 관리자 로그인</h1>
+                <form onSubmit={handleLogin}>
+                    <div className="mb-4">
+                        <label className="block text-sm font-medium text-gray-700 mb-2"></label>
+                        <input
+                            type="text"
+                            placeholder="아이디"
+                            value={adminId}
+                            onChange={(e) => setAdminId(e.target.value)}
+                            required
+                            className="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
+                        />
+                    </div>
+                    <div className="mb-4">
+                        <label className="block text-sm font-medium text-gray-700 mb-2"></label>
+                        <input
+                            type="password"
+                            placeholder="비밀번호"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            required
+                            className="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
+                        />
+                    </div>
+                    {error && !loading && (
+                        <p className="mb-4 text-sm text-red-500">{error}</p>
+                    )}
+                    <button
+                        type="submit"
+                        disabled={loading}
+                        className={`w-full py-2 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 ${
+                            loading
+                                ? "bg-gray-400 cursor-not-allowed"
+                                : "bg-indigo-500 hover:bg-indigo-600"
+                        }`}
+                    >
+                        {loading ? "로그인 중..." : "로그인"}
+                    </button>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/app/(with-admin)/admin/page.tsx
+++ b/frontend/src/app/(with-admin)/admin/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+
+// 관리자 페이지 루트 경로
+// /admin으로 접근 시 /admin/login으로 리다이렉트
+export default function AdminPage() {
+    redirect("/admin/login"); // 서버에서 리다이렉트 처리
+    return null; // 리다이렉트가 실행되므로 UI는 렌더링되지 않음
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-gray-50`}
       >
-        <h1 className="text-center text-2xl font-bold py-6 bg-white shadow-sm text-gray-900">
+        <h1 id="main-header" className="text-center text-2xl font-bold py-6 bg-white shadow-sm text-gray-900">
           Grids & Circles
         </h1>
         <ClientLayout>{children}</ClientLayout>


### PR DESCRIPTION
## 🌿 반영 브랜치
admin/login > main

## 🛠 작업 내용
- admin/login 로그인 페이지 및 레이아웃 파일 추가(로그인 성공 시 admin/board로 이동)
- root/layout 적용 예외처리.
- app/layout.tsx 수정.
 
(추가 커밋)
- 관리자 기본 페이지 추가(/admin.page.tsx)
- /admin 접근 시 /admin/login 리다이렉트 적용.

## 📂 추가 정보
- 관리자 페이지가 최초 '/admin' 이 아닌 '/admin/login' 접근인 이유는 현재 Root/layout의 admin그룹 적용 예외처리가 정상적으로 작동되지 않습니다. 그렇기에 문제 해결을 위해 Depth가 필요해서 admin/login그룹이 만들어졌습니다.
(이 부분 한얼FT님과 월요일에 이어서 해결해보기로 한 상태이며, 우회적 해결법으로는 root/layout을 비워두고 모든 그룹이 개별 layout을 가지는 방법도 가능하다고 생각됩니다.)
- rebase를 한다는 걸 계속 update를 하다보니 브랜치 커밋이 좀 지저분해졌습니다. 양해바랍니다.

## 💬 리뷰 요구사항
- 서버오류반환(handleErrorResponse) 핸들러의 경우 오류의 케이스를 나눠놓았는데, 관리자이기 때문에 알 필요성이 있다고 판단하여 구현하였습니다. 다른 의견 환영합니다.
